### PR TITLE
Add support for categories and bug fixes

### DIFF
--- a/src/json_config/layered_config/config.py
+++ b/src/json_config/layered_config/config.py
@@ -13,6 +13,42 @@ class ConfigValues:
     """Base class for config values.
 
     Should be subclassed to define specific config fields.
+
+    A field may be tagged with ``metadata={"category": "some_name"}`` to mark
+    it as a nested :class:`ConfigValues` that should be represented as a
+    nested object (keyed by its category name) rather than a plain attribute.
+    This lets several logically-distinct sub-configs be combined into a
+    single :class:`ConfigValues` (and persisted through a single
+    :class:`~.config_layer.ConfigLayer`) while still being addressable and
+    resolvable as their own nested structures.
+
+    Example::
+
+        @dataclasses.dataclass
+        class MainWindowValues(ConfigValues):
+            width: int = 100
+            height: int = 100
+
+        @dataclasses.dataclass
+        class EnvValues(ConfigValues):
+            name: str = "test"
+
+        @dataclasses.dataclass
+        class MainValues(ConfigValues):
+            main_window: MainWindowValues = dataclasses.field(
+                default_factory=MainWindowValues, metadata={"category": "main_window"}
+            )
+            env: EnvValues = dataclasses.field(
+                default_factory=EnvValues, metadata={"category": "env"}
+            )
+            root_value: int = 10
+
+        # MainValues().to_dict() ->
+        # {
+        #     "main_window": {"width": 100, "height": 100},
+        #     "env": {"name": "test"},
+        #     "root_value": 10,
+        # }
     """
 
     @classmethod
@@ -24,30 +60,90 @@ class ConfigValues:
         """
         return set(each_field.name for each_field in dataclasses.fields(cls))
 
-    @classmethod
-    def get_defaults(cls) -> dict[str, typing.Any]:
-        """Return a dict of field names to their default values.
+    @staticmethod
+    def _field_key(field: dataclasses.Field) -> str:
+        """Return the key a field should be addressed by.
+
+        This is the field's ``category`` metadata if set, otherwise its own
+        attribute name.
+
+        Args:
+            field: The dataclass field to resolve a key for.
 
         Returns:
-            dict[str, Any]: dictionary of field names to their default values
+            str: The resolved key.
+        """
+        return field.metadata.get("category", field.name)
+
+    @classmethod
+    def get_defaults(cls) -> dict[str, typing.Any]:
+        """Return a dict of field/category names to their default values.
+
+        Fields whose default value is itself a :class:`ConfigValues`
+        (typically tagged with ``metadata={"category": ...}``) are expanded
+        recursively into nested dicts, keyed by their category name (or
+        their own attribute name if no category is set).
+
+        Returns:
+            dict[str, Any]: dictionary of keys to their default values
         """
         defaults = {}
         for field in dataclasses.fields(cls):
             if field.default is not dataclasses.MISSING:
-                defaults[field.name] = field.default
+                value = field.default
             elif field.default_factory is not dataclasses.MISSING:
-                defaults[field.name] = field.default_factory()
+                value = field.default_factory()
+            else:
+                continue
+
+            if isinstance(value, ConfigValues):
+                value = value.get_defaults()
+
+            defaults[cls._field_key(field)] = value
 
         return defaults
 
+    def to_dict(self) -> dict[str, typing.Any]:
+        """Convert this instance to a plain (possibly nested) dict.
+
+        Fields tagged with ``metadata={"category": ...}`` are nested under
+        their category name instead of their raw attribute name.
+
+        Returns:
+            dict[str, Any]: dictionary of keys to their current values
+        """
+        result = {}
+        for field in dataclasses.fields(self):
+            value = getattr(self, field.name)
+            if isinstance(value, ConfigValues):
+                value = value.to_dict()
+            result[self._field_key(field)] = value
+        return result
+
     def replace(self, data: dict[str, typing.Any]) -> typing.Self:
-        """Update config values from a dictionary.
+        """Update config values from a (possibly nested) dictionary.
+
+        Keys are matched against each field's category name (if tagged via
+        ``metadata={"category": ...}``) or its attribute name otherwise.
+        Nested :class:`ConfigValues` fields are updated recursively, so
+        nested values absent from *data* are left untouched.
 
         Args:
             data (dict[str, Any]): dictionary of values to update
         """
-        filtered_dict = {k: v for k, v in data.items() if k in self.get_fields_names()}
-        return dataclasses.replace(self, **filtered_dict)
+        updates: dict[str, typing.Any] = {}
+        for field in dataclasses.fields(self):
+            key = self._field_key(field)
+            if key not in data:
+                continue
+
+            value = data[key]
+            current = getattr(self, field.name)
+            if isinstance(current, ConfigValues) and isinstance(value, dict):
+                value = current.replace(value)
+            updates[field.name] = value
+
+        return dataclasses.replace(self, **updates)
 
 
 class LayeredConfig[T]:
@@ -207,9 +303,7 @@ class LayeredConfig[T]:
 
         layer = self.manager[layer_name]
         update_dict = {
-            k: v
-            for k, v in dataclasses.asdict(self._values).items()
-            if k in layer.get_data()
+            k: v for k, v in self._values.to_dict().items() if k in layer.get_data()
         }
         layer.set(**update_dict)
 

--- a/src/json_config/layered_config/config.py
+++ b/src/json_config/layered_config/config.py
@@ -295,6 +295,15 @@ class LayeredConfig[T]:
     def write_to_layer(self, layer_name: str):
         """Write the current values to the specified layer.
 
+        Only the (top-level) fields whose current value differs from what
+        would be resolved from *layer_name*'s own dependencies (i.e. without
+        this layer's own contribution) are written. This keeps a layer's
+        file limited to its own overrides rather than a full copy of
+        inherited values, while still allowing the very first write to a
+        brand new, previously-empty layer to persist correctly (previously,
+        writes were filtered down to keys already present in the layer's
+        data, which meant nothing could ever be written to a fresh layer).
+
         Parameters
         ----------
         layer_name : str
@@ -302,8 +311,11 @@ class LayeredConfig[T]:
         """
 
         layer = self.manager[layer_name]
+        baseline = self.manager.resolve_many(*layer.depends_on)
+        _unset = object()
+        current_dict = self._values.to_dict()
         update_dict = {
-            k: v for k, v in self._values.to_dict().items() if k in layer.get_data()
+            k: v for k, v in current_dict.items() if baseline.get(k, _unset) != v
         }
         layer.set(**update_dict)
 

--- a/src/json_config/layered_config/config_layer.py
+++ b/src/json_config/layered_config/config_layer.py
@@ -54,9 +54,7 @@ class ConfigLayer:
         raw = json.loads(self.file_path.read_text())
 
         if not isinstance(raw, dict):
-            raise ValueError(
-                f"[{self.name}] Expected a JSON object in {self.file_path}"
-            )
+            raise ValueError(f"[{self.name}] Expected a JSON object in {self.file_path}")
         self._data = raw
         LOGGER.info(f"[{self.name}] Loaded from {self.file_path}")
 

--- a/src/json_config/layered_config/config_manager.py
+++ b/src/json_config/layered_config/config_manager.py
@@ -176,7 +176,12 @@ class LayeredConfigManager(metaclass=_ManagerMeta):
         return topological_sort_layers(self._layers)
 
     def _reachable_subgraph(self, name: str) -> dict[str, ConfigLayer]:
-        """Return the layers reachable from *name* (including itself)."""
+        """Return the layers reachable from *name* (including itself).
+
+        Raises:
+            ValueError: if *name* or any of its transitive dependencies is
+                not registered with this manager.
+        """
         seen: set[str] = set()
         stack = [name]
         while stack:
@@ -184,7 +189,10 @@ class LayeredConfigManager(metaclass=_ManagerMeta):
             if current in seen:
                 continue
             seen.add(current)
-            stack.extend(self._layers[current].depends_on)
+            layer = self._layers.get(current)
+            if layer is None:
+                raise ValueError(f"Layer '{current}' is not registered.")
+            stack.extend(layer.depends_on)
         return {k: self._layers[k] for k in seen}
 
     # ------------------------------------------------------------------

--- a/src/json_config/simple_config.py
+++ b/src/json_config/simple_config.py
@@ -15,10 +15,19 @@ class Singleton(type):
             cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
-    @classmethod
     def clear_instances(cls):
-        """Clear all instances of the class."""
-        cls._instances.clear()
+        """Clear the cached singleton instance of this class.
+
+        Note:
+            This is a plain metaclass method (not a ``@classmethod``) so that
+            ``cls`` binds to the concrete class it was called on (e.g.
+            ``MyConfig``) rather than to the ``Singleton`` metaclass itself.
+            Using ``@classmethod`` here would make ``cls`` resolve to
+            ``Singleton`` for every subclass, causing ``cls._instances.clear()``
+            to wipe out the cached instances of *every* ``SimpleConfig``
+            subclass instead of just this one.
+        """
+        cls._instances.pop(cls, None)
 
 
 @dataclasses.dataclass
@@ -72,7 +81,7 @@ class SimpleConfig(metaclass=Singleton):
         """
         cls.clear_instances()
         instance = cls()
-        cls.FILE_PATH.parent.mkdir(exist_ok=True)
+        cls.FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
         with cls.FILE_PATH.open("w") as config_file:
             json.dump(dataclasses.asdict(instance), config_file, indent=4)
 
@@ -87,10 +96,10 @@ class SimpleConfig(metaclass=Singleton):
         Returns:
             Config: new instance
         """
-        if cls._instances:
+        if cls in cls._instances:
             return cls()
 
-        cls.FILE_PATH.parent.mkdir(exist_ok=True)
+        cls.FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
         if not cls.FILE_PATH.is_file():
             return cls.reset()
 
@@ -100,7 +109,7 @@ class SimpleConfig(metaclass=Singleton):
     def save(cls):
         """Write config to json file."""
         instance = cls()
-        cls.FILE_PATH.parent.mkdir(exist_ok=True)
+        cls.FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
         with cls.FILE_PATH.open("w") as config_file:
             json.dump(dataclasses.asdict(instance), config_file, indent=4)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
+import dataclasses
 import pathlib
 
 import pytest
 
-from json_config.api import ConfigLayer, LayeredConfigManager, SimpleConfig
+from json_config.api import ConfigLayer, ConfigValues, LayeredConfigManager, SimpleConfig
 
 TESTS_DIR = pathlib.Path.cwd() / "tests"
 FIXTURES_DIR = TESTS_DIR / "fixtures"
@@ -24,6 +25,77 @@ USER2_FIXTURE = FIXTURE_USER_LAYERS_DIR / "user2.json"
 LAYER_TESTING_FIXTURES_DIR = FIXTURES_DIR / "layer_testing"
 EMPTY_LAYER_FILE = LAYER_TESTING_FIXTURES_DIR / "empty_layer.json"
 INVALID_NOT_DICT_LAYER = LAYER_TESTING_FIXTURES_DIR / "invalid_not_dict_layer.json"
+
+
+# ---------------------------------------------------------------------------
+# ConfigValues category-nesting fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _CategoryAValues(ConfigValues):
+    field_one: int = 100
+    field_two: int = 100
+
+
+@dataclasses.dataclass
+class _CategoryBValues(ConfigValues):
+    label: str = "test"
+
+
+@dataclasses.dataclass
+class _CategoryValues(ConfigValues):
+    """ConfigValues with a single level of category nesting.
+
+    Structure::
+
+        category_a (category) -> field_one, field_two
+        category_b (category) -> label
+        flat_value            -> flat field
+    """
+
+    category_a: _CategoryAValues = dataclasses.field(
+        default_factory=_CategoryAValues, metadata={"category": "category_a"}
+    )
+    category_b: _CategoryBValues = dataclasses.field(
+        default_factory=_CategoryBValues, metadata={"category": "category_b"}
+    )
+    flat_value: int = 10
+
+
+@dataclasses.dataclass
+class _SubCategoryValues(ConfigValues):
+    x: int = 0
+    y: int = 0
+
+
+@dataclasses.dataclass
+class _NestedCategoryAValues(ConfigValues):
+    field_one: int = 100
+    field_two: int = 100
+    sub_category: _SubCategoryValues = dataclasses.field(
+        default_factory=_SubCategoryValues, metadata={"category": "sub_category"}
+    )
+
+
+@dataclasses.dataclass
+class _NestedCategoryValues(ConfigValues):
+    """ConfigValues with three levels of category nesting.
+
+    Structure::
+
+        category_a (category) -> field_one, field_two, sub_category (category) -> x, y
+        category_b (category) -> label
+        flat_value            -> flat field
+    """
+
+    category_a: _NestedCategoryAValues = dataclasses.field(
+        default_factory=_NestedCategoryAValues, metadata={"category": "category_a"}
+    )
+    category_b: _CategoryBValues = dataclasses.field(
+        default_factory=_CategoryBValues, metadata={"category": "category_b"}
+    )
+    flat_value: int = 10
 
 
 @pytest.fixture(autouse=True)
@@ -131,6 +203,28 @@ def preset_user_manager() -> LayeredConfigManager:
     manager.register(user2_layer)
     yield manager
     LayeredConfigManager.clear()
+
+
+@pytest.fixture()
+def category_values_class() -> type[_CategoryValues]:
+    """ConfigValues class with a single level of category nesting.
+
+    Returns:
+        type[_CategoryValues]: The ConfigValues subclass
+            (category_a/category_b/flat_value).
+    """
+    return _CategoryValues
+
+
+@pytest.fixture()
+def nested_category_values_class() -> type[_NestedCategoryValues]:
+    """ConfigValues class with three levels of category nesting.
+
+    Returns:
+        type[_NestedCategoryValues]: The ConfigValues subclass with a nested
+            category_a.sub_category category.
+    """
+    return _NestedCategoryValues
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import dataclasses
 import pathlib
+import shutil
 
 import pytest
 
@@ -7,6 +8,7 @@ from json_config.api import ConfigLayer, ConfigValues, LayeredConfigManager, Sim
 
 TESTS_DIR = pathlib.Path.cwd() / "tests"
 FIXTURES_DIR = TESTS_DIR / "fixtures"
+TEST_OUTPUT_DIR = pathlib.Path.cwd() / ".test_output"
 
 # Config testing fixtures
 CONFIG_TESTING_FIXTURES_DIR = FIXTURES_DIR / "config_testing"
@@ -98,6 +100,18 @@ class _NestedCategoryValues(ConfigValues):
     flat_value: int = 10
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _clean_test_output_dir() -> None:
+    """Remove any leftover .test_output directory at the start of the session.
+
+    The various *_output_dir fixtures below only ever `mkdir(exist_ok=True)`
+    and never clean up after themselves, so stale files from a previous run
+    (e.g. written under an old field/category name) could otherwise bleed
+    into a fresh run's assertions.
+    """
+    shutil.rmtree(TEST_OUTPUT_DIR, ignore_errors=True)
+
+
 @pytest.fixture(autouse=True)
 def fresh_manager() -> None:
     yield
@@ -118,9 +132,8 @@ def output_dir() -> pathlib.Path:
         pathlib.Path: path to test output directory.
 
     """
-    out_dir = pathlib.Path.cwd() / ".test_output"
-    out_dir.mkdir(exist_ok=True)
-    return out_dir
+    TEST_OUTPUT_DIR.mkdir(exist_ok=True)
+    return TEST_OUTPUT_DIR
 
 
 @pytest.fixture(scope="session")
@@ -131,7 +144,7 @@ def simple_config_output_dir() -> pathlib.Path:
         pathlib.Path: path to test output directory.
 
     """
-    out_dir = pathlib.Path.cwd() / ".test_output" / "simple_config"
+    out_dir = TEST_OUTPUT_DIR / "simple_config"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 
@@ -144,7 +157,7 @@ def layered_config_output_dir() -> pathlib.Path:
         pathlib.Path: path to test output directory.
 
     """
-    out_dir = pathlib.Path.cwd() / ".test_output" / "layered_config"
+    out_dir = TEST_OUTPUT_DIR / "layered_config"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 
@@ -156,7 +169,7 @@ def manager_output_dir() -> pathlib.Path:
     Returns:
         pathlib.Path: path to test output directory.
     """
-    out_dir = pathlib.Path.cwd() / ".test_output" / "manager"
+    out_dir = TEST_OUTPUT_DIR / "manager"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 
@@ -168,7 +181,7 @@ def config_layer_output_dir() -> pathlib.Path:
     Returns:
         pathlib.Path: path to test output directory.
     """
-    out_dir = pathlib.Path.cwd() / ".test_output" / "config_layer"
+    out_dir = TEST_OUTPUT_DIR / "config_layer"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 

--- a/tests/layered_config/test_config.py
+++ b/tests/layered_config/test_config.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 import pathlib
 
 import pytest
@@ -59,6 +60,7 @@ def test_defaults_writing(
         list_value: list[str] = dataclasses.field(
             default_factory=lambda: ["a", "b", "c"]
         )
+        dataclasses.field()
 
     class TestConfig(LayeredConfig[TestValues]):
         VALUES_CLASS = TestValues
@@ -172,3 +174,166 @@ def test_reset_values():
     assert config.values.name != config.defaults().name
     config.reset()
     assert config.defaults().name == TestValues().name
+
+
+# ---------------------------------------------------------------------------
+# LayeredConfig + category metadata integration
+# ---------------------------------------------------------------------------
+
+
+def test_layered_config_save_produces_expected_nested_json(
+    category_values_class: type[ConfigValues],
+    layered_config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Test that saving a ConfigValues with category fields produces the
+    expected nested JSON structure through a single ConfigLayer/file."""
+
+    class TestConfig(LayeredConfig[category_values_class]):
+        VALUES_CLASS = category_values_class
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root", file_path=layered_config_output_dir / f"{request.node.name}_config.json"
+    )
+    manager.register(root_layer)
+    manager.load_all()
+
+    config = TestConfig(manager)
+    config.save()
+
+    on_disk = json.loads(root_layer.file_path.read_text())
+    assert on_disk == {
+        "category_a": {"field_one": 100, "field_two": 100},
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }
+
+
+def test_layered_config_roundtrip_mutating_nested_category_value(
+    category_values_class: type[ConfigValues],
+    layered_config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Test load -> resolve -> mutate a nested category value -> save round-trips."""
+
+    class TestConfig(LayeredConfig[category_values_class]):
+        VALUES_CLASS = category_values_class
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root", file_path=layered_config_output_dir / f"{request.node.name}_config.json"
+    )
+    manager.register(root_layer)
+    manager.load_all()
+
+    config = TestConfig(manager)
+    config.save()
+
+    manager.load_all()
+    config2 = TestConfig(manager)
+    config2.resolve()
+    config2.values.category_a.field_one = 1920
+    config2.save()
+
+    on_disk = json.loads(root_layer.file_path.read_text())
+    assert on_disk == {
+        "category_a": {"field_one": 1920, "field_two": 100},
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }
+
+
+def test_layered_config_deep_merges_nested_category_across_layers(
+    category_values_class: type[ConfigValues],
+    layered_config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Test that a child layer overriding only part of a category is deep-merged
+    with the root layer's defaults for that same category."""
+    root_layer = ConfigLayer(
+        "root",
+        file_path=layered_config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=layered_config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager = LayeredConfigManager()
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    class TestConfig(LayeredConfig[category_values_class]):
+        VALUES_CLASS = category_values_class
+
+    config = TestConfig(manager)
+    #! Seed root defaults without resolving, matching test_defaults_writing.
+    config.save()
+
+    # Child layer only overrides one field of category_a; the sibling field
+    # should still come from the root layer's seeded defaults after a deep merge.
+    child_layer.set(category_a={"field_one": 4000})
+    manager.save("child")
+
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+
+    assert config2.values.category_a.field_one == 4000
+    assert config2.values.category_a.field_two == 100
+    assert config2.values.category_b.label == "test"
+    assert config2.values.flat_value == 10
+
+
+def test_layered_config_roundtrip_with_three_levels_of_nesting(
+    nested_category_values_class: type[ConfigValues],
+    layered_config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Regression test: save/load/mutate/save round-trips correctly through
+    three levels of category nesting (category_a.sub_category.x/y)."""
+
+    class TestConfig(LayeredConfig[nested_category_values_class]):
+        VALUES_CLASS = nested_category_values_class
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root", file_path=layered_config_output_dir / f"{request.node.name}_config.json"
+    )
+    manager.register(root_layer)
+    manager.load_all()
+
+    config = TestConfig(manager)
+    config.save()
+
+    on_disk = json.loads(root_layer.file_path.read_text())
+    assert on_disk == {
+        "category_a": {
+            "field_one": 100,
+            "field_two": 100,
+            "sub_category": {"x": 0, "y": 0},
+        },
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }
+
+    # Mutate only the deepest (level-3) values and re-save.
+    manager.load_all()
+    config2 = TestConfig(manager)
+    config2.resolve()
+    config2.values.category_a.sub_category.x = 42
+    config2.values.category_a.sub_category.y = 84
+    config2.save()
+
+    on_disk = json.loads(root_layer.file_path.read_text())
+    assert on_disk == {
+        "category_a": {
+            "field_one": 100,
+            "field_two": 100,
+            "sub_category": {"x": 42, "y": 84},
+        },
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }

--- a/tests/layered_config/test_config.py
+++ b/tests/layered_config/test_config.py
@@ -93,9 +93,7 @@ def test_defaults_writing(
     # After saving files for root layers should contain the defaults
     manager.load_all()
     assert (
-        root_layer.get_data()
-        == extra_root_layer.get_data()
-        == TestValues.get_defaults()
+        root_layer.get_data() == extra_root_layer.get_data() == TestValues.get_defaults()
     )
     # The extra layer file should not be created as it's empty
     assert extra_child_layer.get_data() == {}

--- a/tests/layered_config/test_config.py
+++ b/tests/layered_config/test_config.py
@@ -335,3 +335,53 @@ def test_layered_config_roundtrip_with_three_levels_of_nesting(
         "category_b": {"label": "test"},
         "flat_value": 10,
     }
+
+
+def test_save_to_fresh_child_layer_persists_changed_values(
+    layered_config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Regression test: saving with a layer filter pointing at a child layer
+    that has never been written to before must actually persist the current
+    values.
+
+    Previously, ``write_to_layer`` only wrote keys that already existed in
+    the target layer's own data, which meant nothing could ever be written
+    to a brand new, previously-empty layer.
+    """
+
+    @dataclasses.dataclass
+    class TestValues(ConfigValues):
+        theme: str = "light"
+        font_size: int = 12
+
+    class TestConfig(LayeredConfig[TestValues]):
+        VALUES_CLASS = TestValues
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root", file_path=layered_config_output_dir / f"{request.node.name}_root.json"
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=layered_config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    config = TestConfig(manager, layer_filter="child")
+    config.resolve()
+    config.values.theme = "dark"
+    config.save()
+
+    # The change was persisted...
+    assert child_layer.get_data() == {"theme": "dark"}
+    assert child_layer.file_path.is_file()
+    # ...but the unchanged sibling field is not duplicated into the child
+    # layer -- it should stay a sparse override file.
+    assert "font_size" not in child_layer.get_data()
+
+    on_disk = json.loads(child_layer.file_path.read_text())
+    assert on_disk == {"theme": "dark"}

--- a/tests/layered_config/test_config_manager.py
+++ b/tests/layered_config/test_config_manager.py
@@ -82,9 +82,7 @@ def test_init_from_path_tree(
     assert manager["main"].get_data() != manager.resolve()
     assert manager["user"].get_data()["int_value"] == manager.resolve()["int_value"]
     assert manager["user"].get_data()["dict_value"] == manager.resolve()["dict_value"]
-    assert (
-        manager["workspace"].get_data()["str_value"] == manager.resolve()["str_value"]
-    )
+    assert manager["workspace"].get_data()["str_value"] == manager.resolve()["str_value"]
 
 
 def test_load_layer_missing_dependancy_value_error():

--- a/tests/layered_config/test_config_manager.py
+++ b/tests/layered_config/test_config_manager.py
@@ -168,3 +168,19 @@ def test_root_layers(output_dir: pathlib.Path):
 
     assert len(manager.root_layers) == 3
     assert manager.root_layers == ["root1", "root2", "root3"]
+
+
+def test_resolve_up_to_missing_dependency_raises_value_error() -> None:
+    """Regression test: resolving/sorting "up to" a layer with a missing
+    dependency must raise a ValueError, consistent with the no-`up_to` path
+    (sorted_names()/load_all()), instead of a bare KeyError.
+    """
+    manager = LayeredConfigManager()
+    test_layer = ConfigLayer("test", depends_on=["missing"])
+    manager.register(test_layer)
+
+    with pytest.raises(ValueError):
+        manager.sorted_names(up_to="test")
+
+    with pytest.raises(ValueError):
+        manager.resolve(up_to="test")

--- a/tests/layered_config/test_config_values.py
+++ b/tests/layered_config/test_config_values.py
@@ -1,0 +1,149 @@
+import dataclasses
+
+from json_config.api import ConfigValues
+
+# ---------------------------------------------------------------------------
+# category metadata support (single level of nesting)
+# ---------------------------------------------------------------------------
+
+
+def test_get_defaults_expands_category_fields_into_nested_dicts(
+    category_values_class: type[ConfigValues],
+):
+    """Test that get_defaults() nests category-tagged fields by category name."""
+    assert category_values_class.get_defaults() == {
+        "category_a": {"field_one": 100, "field_two": 100},
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }
+
+
+def test_to_dict_nests_category_fields_by_category_name(
+    category_values_class: type[ConfigValues],
+):
+    """Test that to_dict() mirrors get_defaults() for a freshly built instance."""
+    values = category_values_class()
+    assert values.to_dict() == {
+        "category_a": {"field_one": 100, "field_two": 100},
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }
+
+
+def test_to_dict_reflects_mutated_nested_values(
+    category_values_class: type[ConfigValues],
+):
+    """Test that to_dict() reflects in-place mutations of nested category values."""
+    values = category_values_class()
+    values.category_a.field_one = 1920
+    values.flat_value = 42
+    assert values.to_dict() == {
+        "category_a": {"field_one": 1920, "field_two": 100},
+        "category_b": {"label": "test"},
+        "flat_value": 42,
+    }
+
+
+def test_replace_updates_nested_category_field_and_preserves_siblings(
+    category_values_class: type[ConfigValues],
+):
+    """Test that replace() recurses into category fields, keyed by category name."""
+    values = category_values_class()
+    updated = values.replace({"category_a": {"field_one": 1024}})
+
+    assert updated.category_a.field_one == 1024
+    # field_two wasn't in the update dict, so it should be preserved.
+    assert updated.category_a.field_two == 100
+    # Unrelated category and flat field must be untouched.
+    assert updated.category_b.label == "test"
+    assert updated.flat_value == 10
+
+
+def test_replace_with_full_nested_dict(category_values_class: type[ConfigValues]):
+    """Test that replace() accepts a fully-specified nested dict (round-trip)."""
+    values = category_values_class()
+    resolved = values.to_dict()
+    resolved["category_a"]["field_one"] = 4
+    resolved["category_b"]["label"] = "prod"
+    resolved["flat_value"] = 99
+
+    updated = values.replace(resolved)
+    assert updated.to_dict() == resolved
+
+
+def test_category_key_can_differ_from_field_name():
+    """Test that the category metadata value, not the attribute name, is used
+    as the serialized key."""
+
+    @dataclasses.dataclass
+    class InnerValues(ConfigValues):
+        value: int = 1
+
+    @dataclasses.dataclass
+    class OuterValues(ConfigValues):
+        inner: InnerValues = dataclasses.field(
+            default_factory=InnerValues, metadata={"category": "renamed"}
+        )
+
+    values = OuterValues()
+    assert values.to_dict() == {"renamed": {"value": 1}}
+    assert OuterValues.get_defaults() == {"renamed": {"value": 1}}
+
+    updated = values.replace({"renamed": {"value": 5}})
+    assert updated.inner.value == 5
+
+
+# ---------------------------------------------------------------------------
+# multi-level (3+) category nesting
+# ---------------------------------------------------------------------------
+
+
+def test_get_defaults_supports_three_levels_of_category_nesting(
+    nested_category_values_class: type[ConfigValues],
+):
+    """Test that get_defaults() recurses through multiple levels of nesting."""
+    assert nested_category_values_class.get_defaults() == {
+        "category_a": {
+            "field_one": 100,
+            "field_two": 100,
+            "sub_category": {"x": 0, "y": 0},
+        },
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }
+
+
+def test_to_dict_supports_three_levels_of_category_nesting(
+    nested_category_values_class: type[ConfigValues],
+):
+    """Test that to_dict() recurses through multiple levels of nesting."""
+    values = nested_category_values_class()
+    assert values.to_dict() == {
+        "category_a": {
+            "field_one": 100,
+            "field_two": 100,
+            "sub_category": {"x": 0, "y": 0},
+        },
+        "category_b": {"label": "test"},
+        "flat_value": 10,
+    }
+
+
+def test_replace_updates_deeply_nested_category_and_preserves_siblings(
+    nested_category_values_class: type[ConfigValues],
+):
+    """Test that replace() recurses through multiple levels, keyed by category,
+    leaving sibling values at every level untouched."""
+    values = nested_category_values_class()
+    updated = values.replace({"category_a": {"sub_category": {"x": 42}}})
+
+    # The deeply-nested value was updated.
+    assert updated.category_a.sub_category.x == 42
+    # Its sibling at the same (deepest) level is preserved.
+    assert updated.category_a.sub_category.y == 0
+    # Siblings at the intermediate level are preserved.
+    assert updated.category_a.field_one == 100
+    assert updated.category_a.field_two == 100
+    # Unrelated top-level category and flat field are untouched.
+    assert updated.category_b.label == "test"
+    assert updated.flat_value == 10

--- a/tests/test_simple_config.py
+++ b/tests/test_simple_config.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 
 import pytest
@@ -66,3 +67,82 @@ def test_get_fields_names(
     TestConfig.load()
     field_names = TestConfig.get_fields_names()
     assert field_names == {"int_value", "str_value"}
+
+
+def test_multiple_config_classes_do_not_share_singleton_cache(
+    simple_config_output_dir: pathlib.Path, request: pytest.FixtureRequest
+):
+    """Regression test: resetting one SimpleConfig subclass must not clear
+    or evict the cached singleton instance of a different subclass.
+
+    ``Singleton._instances`` is a single dict shared by every SimpleConfig
+    subclass (keyed by class). ``clear_instances()`` must only remove *its
+    own* class's entry from that shared dict.
+    """
+
+    class ConfigA(SimpleConfig):
+        FILE_PATH = simple_config_output_dir / f"{request.node.name}_a_config.json"
+
+        value: int = 1
+
+    class ConfigB(SimpleConfig):
+        FILE_PATH = simple_config_output_dir / f"{request.node.name}_b_config.json"
+
+        value: int = 2
+
+    a = ConfigA.load()
+    b = ConfigB.load()
+    a.value = 100
+    b.value = 200
+
+    ConfigA.reset()
+
+    assert ConfigB() is b
+    assert ConfigB().value == 200
+
+
+def test_loading_one_config_class_does_not_skip_loading_another(
+    simple_config_output_dir: pathlib.Path, request: pytest.FixtureRequest
+):
+    """Regression test: load() must check whether *this specific* class
+    already has a cached singleton instance, not whether *any*
+    SimpleConfig subclass does.
+    """
+
+    class ConfigA(SimpleConfig):
+        FILE_PATH = simple_config_output_dir / f"{request.node.name}_a_config.json"
+
+        value: int = 1
+
+    # Prime the shared singleton registry with ConfigA's cached instance.
+    ConfigA.load()
+
+    b_path = simple_config_output_dir / f"{request.node.name}_b_config.json"
+    b_path.write_text(json.dumps({"value": 999}))
+
+    class ConfigB(SimpleConfig):
+        FILE_PATH = b_path
+
+        value: int = 2
+
+    instance = ConfigB.load()
+    assert instance.value == 999
+
+
+def test_load_creates_missing_nested_directories(
+    simple_config_output_dir: pathlib.Path, request: pytest.FixtureRequest
+):
+    """Regression test: FILE_PATH nested several directories deep (where
+    none of the intermediate directories exist yet) must be created
+    correctly rather than raising FileNotFoundError.
+    """
+    nested_dir = simple_config_output_dir / request.node.name / "a" / "b" / "c"
+
+    class NestedConfig(SimpleConfig):
+        FILE_PATH = nested_dir / "config.json"
+
+        value: int = 1
+
+    instance = NestedConfig.load()
+    assert instance.value == 1
+    assert NestedConfig.FILE_PATH.is_file()


### PR DESCRIPTION
### Added support for categories

---

```python
import dataclasses, json
from json_config.api import ConfigValues, LayeredConfig, LayeredConfigManager, ConfigLayer
import pathlib

# Level 3 (deepest)
@dataclasses.dataclass
class PositionValues(ConfigValues):
    x: int = 0
    y: int = 0

# Level 2
@dataclasses.dataclass
class MainWindowValues(ConfigValues):
    width: int = 100
    height: int = 100
    position: PositionValues = dataclasses.field(
        default_factory=PositionValues, metadata={'category': 'position'}
    )

@dataclasses.dataclass
class EnvValues(ConfigValues):
    name: str = 'test'

# Level 1 (top)
@dataclasses.dataclass
class MainConfigValues(ConfigValues):
    main_window: MainWindowValues = dataclasses.field(
        default_factory=MainWindowValues, metadata={'category': 'main_window'}
    )
    env: EnvValues = dataclasses.field(
        default_factory=EnvValues, metadata={'category': 'env'}
    )
    root_value: int = 10

class TestConfig(LayeredConfig[MainConfigValues]):
    VALUES_CLASS = MainConfigValues

manager = LayeredConfigManager()
root_layer = ConfigLayer('root', file_path=pathlib.Path('.test_output/nested3_test.json'))
manager.register(root_layer)
manager.load_all()

config = TestConfig(manager)
config.save()
print('--- after first save ---')
print(json.dumps(json.loads(root_layer.file_path.read_text()), indent=2))

# Now mutate a level-3 (deeply nested) value and re-save
manager.load_all()
config2 = TestConfig(manager)
config2.resolve()
config2.values.main_window.position.x = 42
config2.values.main_window.position.y = 84
config2.save()
```


### Bugfixes

---

1. **`Singleton.clear_instances` wiped out *every* `SimpleConfig` subclass's cached instance** (`src/json_config/simple_config.py`)
   `clear_instances` was a `@classmethod` defined on the metaclass. Metaclass classmethods always bind `cls` to the metaclass itself (not the concrete subclass), so `cls._instances.clear()` cleared the *entire shared* registry. Calling `ConfigA.reset()` would silently discard `ConfigB`'s in-memory singleton. Fixed by making it a plain metaclass method (so `cls` binds correctly) and popping only that class's own entry.

2. **`SimpleConfig.load()` skipped loading from disk if *any* other config class had already been cached** (`src/json_config/simple_config.py`)
   `if cls._instances:` checked whether the shared dict was non-empty at all, rather than `cls in cls._instances`. Once any `SimpleConfig` subclass was loaded, every other subclass's first `.load()` call would return an unloaded default instance instead of reading its own JSON file.

3. **`LayeredConfig.write_to_layer` could never write to a brand-new, previously-empty layer** (`src/json_config/layered_config/config.py`)
   It filtered updates to keys already present in the layer's own data, so writing an override to a fresh child layer for the first time was silently a no-op. Rewrote it to diff current values against what's inherited from the layer's dependencies (`resolve_many`), so first-time writes persist while unrelated/unchanged values still aren't duplicated (layers stay sparse).

4. **`LayeredConfigManager.resolve(up_to=...)` raised a bare `KeyError` instead of the documented `ValueError`** for missing dependencies (`src/json_config/layered_config/config_manager.py`). Fixed `_reachable_subgraph` to validate registration consistently with the non-`up_to` path.

5. Also fixed a related robustness issue: `SimpleConfig`'s directory creation used `mkdir(exist_ok=True)` (no `parents=True`), so a `FILE_PATH` nested more than one directory deep would raise `FileNotFoundError`. Made it consistent with `ConfigLayer.save()`.

### Tests added
- `tests/test_simple_config.py`: singleton isolation, cross-class load isolation, nested-directory creation.
- `tests/layered_config/test_config.py`: saving to a fresh child layer.
- `tests/layered_config/test_config_manager.py`: `ValueError` for missing dependency via `up_to`.