### PR TITLE
Implement clearance of non-overrides and value revert (#16)

### DIFF
--- a/src/json_config/api/__init__.py
+++ b/src/json_config/api/__init__.py
@@ -1,10 +1,10 @@
 from ..core.config import ConfigValues, LayeredConfig
 from ..core.config_layer import ConfigLayer
-from ..core.config_manager import LayeredConfigManager
+from ..core.layer_manager import ConfigLayerManager
 
 __all__ = [
     "ConfigLayer",
     "ConfigValues",
     "LayeredConfig",
-    "LayeredConfigManager",
+    "ConfigLayerManager",
 ]

--- a/src/json_config/core/config.py
+++ b/src/json_config/core/config.py
@@ -3,7 +3,7 @@ import logging
 import typing
 
 from ..utils import layer_helpers
-from .config_manager import LayeredConfigManager
+from .layer_manager import ConfigLayerManager
 
 LOGGER = logging.getLogger(__name__)
 T = typing.TypeVar("T", bound="ConfigValues")
@@ -189,19 +189,19 @@ class LayeredConfig[T]:
 
     def __init__(
         self,
-        config_manager: LayeredConfigManager | None = None,
+        layer_manager: ConfigLayerManager | None = None,
         layer_filter: str | None = None,
     ):
         """Initialize the config.
 
         Args:
-            config_manager (LayeredConfigManager | None, optional): The config manager
+            layer_manager (ConfigLayerManager | None, optional): The config manager
                 to use, by default None (a new manager is created).
             layer_filter (str | None, optional): The layer filter to use,
                 by default None (the root layer is used).
         """
-        self._config_manager: LayeredConfigManager = (
-            config_manager if config_manager else LayeredConfigManager()
+        self._layer_manager: ConfigLayerManager = (
+            layer_manager if layer_manager else ConfigLayerManager()
         )
         self._layer_filter: str | None = layer_filter
         self._values: T = self.VALUES_CLASS()
@@ -219,17 +219,17 @@ class LayeredConfig[T]:
         return self._layer_filter in self.layers
 
     @property
-    def manager(self) -> LayeredConfigManager:
+    def layer_manager(self) -> ConfigLayerManager:
         """
-        Return the config manager.
+        Return the config layer manager.
 
         Raises:
-            ValueError: If the config manager is not set.
+            ValueError: If the config layer manager is not set.
 
         Returns:
-            LayeredConfigManager: The config manager.
+            ConfigLayerManager: The config layer manager.
         """
-        return self._config_manager
+        return self._layer_manager
 
     @property
     def root_layers(self) -> list[str]:
@@ -238,7 +238,7 @@ class LayeredConfig[T]:
         Returns:
             dict[str, Any]: The root layers.
         """
-        return self._config_manager.root_layers
+        return self._layer_manager.root_layers
 
     @property
     def current_layer(self) -> str:
@@ -257,7 +257,7 @@ class LayeredConfig[T]:
             list[str]: The list of layer names.
         """
 
-        return list(self._config_manager.sorted_names())
+        return list(self._layer_manager.sorted_names())
 
     @property
     def layer_filter(self) -> str | None:
@@ -288,8 +288,8 @@ class LayeredConfig[T]:
         Returns:
             dict[str, typing.Any]: The resolved values.
         """
-        self.manager.load_all()
-        sorted_layer_names = self.manager.sorted_names()
+        self.layer_manager.load_all()
+        sorted_layer_names = self.layer_manager.sorted_names()
         layer_name = sorted_layer_names[0]
         if self.layer_filter in self.layers:
             layer_name = self.layer_filter
@@ -299,7 +299,7 @@ class LayeredConfig[T]:
                 f"valid options are: {self.layers}"
             )
 
-        resolved_dict = self.manager.resolve(up_to=layer_name)
+        resolved_dict = self.layer_manager.resolve(up_to=layer_name)
         self._values = self.values.replace(resolved_dict)
 
         return resolved_dict
@@ -335,8 +335,8 @@ class LayeredConfig[T]:
                 The name of the layer to write to.
         """
 
-        layer = self.manager[layer_name]
-        baseline = self.manager.resolve_many(*layer.depends_on)
+        layer = self.layer_manager[layer_name]
+        baseline = self.layer_manager.resolve_many(*layer.depends_on)
         current_dict = self._values.to_dict()
         diff = layer_helpers.deep_diff_dicts(current_dict, baseline)
         layer.replace_data(diff)
@@ -380,10 +380,10 @@ class LayeredConfig[T]:
                 )
             path = (self.VALUES_CLASS._field_key(field),)
 
-        layer = self.manager[self.current_layer]
+        layer = self.layer_manager[self.current_layer]
         layer.unset_path(path)
 
-        baseline = self.manager.resolve_many(*layer.depends_on)
+        baseline = self.layer_manager.resolve_many(*layer.depends_on)
         defaults = self.VALUES_CLASS.get_defaults()
         _unset = object()
         value = layer_helpers.get_nested(baseline, path, _unset)
@@ -398,7 +398,7 @@ class LayeredConfig[T]:
 
     def save(self):
         """Save the current values to the active layer."""
-        self.manager.seed_root_layers(self.values.get_defaults())
+        self.layer_manager.seed_root_layers(self.values.get_defaults())
         current_layer = self.current_layer
         self.write_to_layer(current_layer)
-        self.manager.save(current_layer)
+        self.layer_manager.save(current_layer)

--- a/src/json_config/core/config.py
+++ b/src/json_config/core/config.py
@@ -2,6 +2,7 @@ import dataclasses
 import logging
 import typing
 
+from ..utils import layer_helpers
 from .config_manager import LayeredConfigManager
 
 LOGGER = logging.getLogger(__name__)
@@ -315,29 +316,81 @@ class LayeredConfig[T]:
     def write_to_layer(self, layer_name: str):
         """Write the current values to the specified layer.
 
-        Only the (top-level) fields whose current value differs from what
-        would be resolved from *layer_name*'s own dependencies (i.e. without
-        this layer's own contribution) are written. This keeps a layer's
-        file limited to its own overrides rather than a full copy of
-        inherited values, while still allowing the very first write to a
-        brand new, previously-empty layer to persist correctly (previously,
-        writes were filtered down to keys already present in the layer's
-        data, which meant nothing could ever be written to a fresh layer).
+        Only the fields whose current value differs from what would be
+        resolved from *layer_name*'s own dependencies (i.e. without this
+        layer's own contribution) are written. This keeps a layer's file
+        limited to its own overrides rather than a full copy of inherited
+        values, while still allowing the very first write to a brand new,
+        previously-empty layer to persist correctly (previously, writes
+        were filtered down to keys already present in the layer's data,
+        which meant nothing could ever be written to a fresh layer).
 
-        Parameters
-        ----------
-        layer_name : str
-            The name of the layer to write to.
+        The diff is computed recursively, so nested category values are
+        pruned on a per-field basis: if only part of a nested category still
+        diverges from the baseline, only that part is kept as an override,
+        and fields that now match the baseline (at any depth) are dropped.
+
+        Args:
+            layer_name : str
+                The name of the layer to write to.
         """
 
         layer = self.manager[layer_name]
         baseline = self.manager.resolve_many(*layer.depends_on)
-        _unset = object()
         current_dict = self._values.to_dict()
-        update_dict = {
-            k: v for k, v in current_dict.items() if baseline.get(k, _unset) != v
-        }
-        layer.set(**update_dict)
+        diff = layer_helpers.deep_diff_dicts(current_dict, baseline)
+        layer.replace_data(diff)
+
+    def revert_value(self, field_or_path: dataclasses.Field | str) -> None:
+        """Revert a field's value to what is inherited from the current
+        layer's dependencies, discarding any override for it on that layer.
+
+        This immediately removes the field's own override from the current
+        layer's raw data, and updates :attr:`values` to reflect the value
+        that would be resolved without that layer's own contribution
+        (falling back to the field's default if no dependency provides a
+        value for it either). Call :meth:`save` afterwards to persist the
+        change to disk.
+
+        Args:
+            field_or_path: Either a ``dataclasses.Field`` belonging to this
+                config's ``VALUES_CLASS`` (reverts that whole top-level
+                field -- for a category field, this discards *all* of its
+                nested overrides), or a dot-separated path string
+                addressing a single, possibly nested, leaf field by its
+                category/attribute keys, e.g. ``"category_a.field_one"``.
+                A nested path only discards the override for that one leaf
+                field, leaving sibling overrides within the same category
+                untouched -- e.g.::
+
+                    config.revert_value("subcategory.option1")
+
+        Raises:
+            ValueError: If *field_or_path* is a ``dataclasses.Field`` that
+                does not belong to this config's ``VALUES_CLASS``.
+        """
+        if isinstance(field_or_path, str):
+            path: tuple[str, ...] = tuple(field_or_path.split("."))
+        else:
+            field = field_or_path
+            if field.name not in self.VALUES_CLASS.get_fields_names():
+                raise ValueError(
+                    f"Field '{field.name}' is not a field of "
+                    f"{self.VALUES_CLASS.__name__}"
+                )
+            path = (self.VALUES_CLASS._field_key(field),)
+
+        layer = self.manager[self.current_layer]
+        layer.unset_path(path)
+
+        baseline = self.manager.resolve_many(*layer.depends_on)
+        defaults = self.VALUES_CLASS.get_defaults()
+        _unset = object()
+        value = layer_helpers.get_nested(baseline, path, _unset)
+        if value is _unset:
+            value = layer_helpers.get_nested(defaults, path, _unset)
+        if value is not _unset:
+            self._values = self._values.replace(layer_helpers.nest_value(path, value))
 
     def reset(self):
         """Reset the current values to the defaults."""

--- a/src/json_config/core/config_layer.py
+++ b/src/json_config/core/config_layer.py
@@ -2,7 +2,10 @@ import dataclasses
 import json
 import logging
 import pathlib
+from collections.abc import Sequence
 from typing import Any
+
+from ..utils import layer_helpers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +33,45 @@ class ConfigLayer:
     def set(self, **kwargs: Any) -> None:
         """Update this layer's values."""
         self._data.update(kwargs)
+
+    def unset(self, *keys: str) -> None:
+        """Remove *keys* from this layer's own data, if present.
+
+        Used to drop overrides that have become redundant (i.e. equal to
+        what would already be inherited from this layer's dependencies),
+        keeping the layer limited to genuine overrides.
+
+        Args:
+            *keys: str
+                The keys to remove from this layer's data.
+        """
+        for key in keys:
+            self._data.pop(key, None)
+
+    def unset_path(self, path: Sequence[str]) -> None:
+        """Remove a (possibly nested) value from this layer's own data.
+
+        Unlike :meth:`unset`, this can target a single leaf value nested
+        within a category override (e.g. ``("category_a", "field_one")``)
+        without discarding sibling overrides in that same category. Any
+        parent container that becomes empty as a result is removed too.
+
+        Args:
+            path: Sequence of keys addressing the value to remove.
+        """
+        layer_helpers.pop_nested(self._data, path)
+
+    def replace_data(self, data: dict[str, Any]) -> None:
+        """Fully replace this layer's own data with *data*.
+
+        Unlike :meth:`set`, this does not merge with the existing data --
+        any previously-stored keys not present in *data* are dropped. Used
+        when writing a fully pruned set of overrides back to the layer.
+
+        Args:
+            data: The new raw field-value mapping for this layer.
+        """
+        self._data = dict(data)
 
     def get_data(self) -> dict[str, Any]:
         """Return a shallow copy of this layer's raw data."""
@@ -63,7 +105,8 @@ class ConfigLayer:
         if self.file_path is None:
             raise RuntimeError(f"Layer '{self.name}' has no file_path set.")
 
-        if not self.get_data():
+        # If layer has no data and the file does not exist, skip saving.
+        if not self.get_data() and not self.file_path.is_file():
             LOGGER.debug(f"[{self.name}] No data to save, skipping.")
             return
 

--- a/src/json_config/core/layer_manager.py
+++ b/src/json_config/core/layer_manager.py
@@ -10,9 +10,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class _ManagerMeta(type):
-    """Singleton metaclass for LayeredConfigManager."""
+    """Singleton metaclass for ConfigLayerManager."""
 
-    _instance: "LayeredConfigManager | None" = None
+    _instance: "ConfigLayerManager | None" = None
 
     def __call__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -23,12 +23,12 @@ class _ManagerMeta(type):
         cls._instance = None
 
 
-class LayeredConfigManager(metaclass=_ManagerMeta):
+class ConfigLayerManager(metaclass=_ManagerMeta):
     """Central manager that owns and resolves all config layers.
 
     Usage::
 
-        manager = LayeredConfigManager()
+        manager = ConfigLayerManager()
 
         # Register layers (order of registration does NOT matter;
         # depends_on drives the merge order).

--- a/src/json_config/utils/layer_helpers.py
+++ b/src/json_config/utils/layer_helpers.py
@@ -1,8 +1,11 @@
 import typing
+from collections.abc import Sequence
 from graphlib import TopologicalSorter
 
 if typing.TYPE_CHECKING:
     from ..api import ConfigLayer
+
+_UNSET = object()
 
 
 def deep_merge_dicts(base: dict, override: dict) -> dict:
@@ -17,6 +20,110 @@ def deep_merge_dicts(base: dict, override: dict) -> dict:
             result[key] = deep_merge_dicts(result[key], value)
         else:
             result[key] = value
+    return result
+
+
+def deep_diff_dicts(current: dict, baseline: dict) -> dict:
+    """Recursively compute the subset of *current* that differs from *baseline*.
+
+    For keys present in both dicts as nested dicts, the diff is computed
+    recursively so that only the genuinely-diverging leaf values are kept,
+    dropping nested keys/sub-keys that match the baseline. All other
+    (non-dict, or newly-added) values are kept as-is if they differ from
+    (or are absent from) *baseline*.
+
+    This is used to prune a config layer down to only its real overrides,
+    including within nested category values.
+
+    Args:
+        current: The full, resolved values to diff.
+        baseline: The values that would already be inherited without
+            *current*'s own contribution.
+
+    Returns:
+        dict: A (possibly nested) dict containing only the differing values.
+    """
+    _unset = object()
+    result = {}
+    for key, value in current.items():
+        base_value = baseline.get(key, _unset)
+        if isinstance(value, dict) and isinstance(base_value, dict):
+            nested_diff = deep_diff_dicts(value, base_value)
+            if nested_diff:
+                result[key] = nested_diff
+        elif base_value is _unset or base_value != value:
+            result[key] = value
+    return result
+
+
+def get_nested(
+    data: dict, path: Sequence[str], default: typing.Any = None
+) -> typing.Any:
+    """Look up a (possibly nested) value in *data* by *path*.
+
+    Args:
+        data: The dict to look up the value in.
+        path: Sequence of keys addressing the value, e.g. ``("category_a",
+            "field_one")`` to look up ``data["category_a"]["field_one"]``.
+        default: Value to return if *path* is not fully present in *data*.
+
+    Returns:
+        Any: The value found at *path*, or *default*.
+    """
+    current: typing.Any = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return default
+        current = current[key]
+    return current
+
+
+def pop_nested(data: dict, path: Sequence[str]) -> None:
+    """Remove the (possibly nested) value at *path* from *data*, in place.
+
+    Any parent dict that becomes empty as a result of the removal is
+    itself removed, so this never leaves behind stale, empty containers.
+
+    Args:
+        data: The dict to remove the value from.
+        path: Sequence of keys addressing the value to remove.
+    """
+    if not path:
+        return
+
+    key, *rest = path
+    if key not in data:
+        return
+
+    if not rest:
+        del data[key]
+        return
+
+    nested = data[key]
+    if isinstance(nested, dict):
+        pop_nested(nested, rest)
+        if not nested:
+            del data[key]
+
+
+def nest_value(path: Sequence[str], value: typing.Any) -> dict:
+    """Wrap *value* in nested dicts following *path*.
+
+    Example::
+
+        nest_value(("category_a", "field_one"), 42)
+        # -> {"category_a": {"field_one": 42}}
+
+    Args:
+        path: Sequence of keys to nest the value under.
+        value: The value to wrap.
+
+    Returns:
+        dict: The nested dict wrapping *value*.
+    """
+    result = value
+    for key in reversed(path):
+        result = {key: result}
     return result
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import shutil
 
 import pytest
 
-from json_config.api import ConfigLayer, ConfigValues, LayeredConfigManager
+from json_config.api import ConfigLayer, ConfigValues, ConfigLayerManager
 
 TESTS_DIR = pathlib.Path.cwd() / "tests"
 FIXTURES_DIR = TESTS_DIR / "fixtures"
@@ -106,7 +106,7 @@ class _NestedCategoryValues(ConfigValues):
 _TEST_OUTPUT_SUBDIRS = (
     "config",
     "config_values",
-    "config_manager",
+    "layer_manager",
     "config_layer",
 )
 
@@ -131,7 +131,7 @@ def _clean_test_output_dir() -> None:
 @pytest.fixture(autouse=True)
 def fresh_manager() -> None:
     yield
-    LayeredConfigManager.clear()
+    ConfigLayerManager.clear()
 
 
 @pytest.fixture(scope="session")
@@ -172,13 +172,13 @@ def config_values_output_dir() -> pathlib.Path:
 
 
 @pytest.fixture(scope="session")
-def config_manager_output_dir() -> pathlib.Path:
-    """Output directory for tests in ``test_config_manager.py``.
+def layer_manager_output_dir() -> pathlib.Path:
+    """Output directory for tests in ``test_layer_manager.py``.
 
     Returns:
         pathlib.Path: path to test output directory.
     """
-    out_dir = TEST_OUTPUT_DIR / "config_manager"
+    out_dir = TEST_OUTPUT_DIR / "layer_manager"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 
@@ -196,8 +196,8 @@ def config_layer_output_dir() -> pathlib.Path:
 
 
 @pytest.fixture()
-def preset_app_manager() -> LayeredConfigManager:
-    manager = LayeredConfigManager()
+def preset_app_manager() -> ConfigLayerManager:
+    manager = ConfigLayerManager()
     main_layer = ConfigLayer("main", file_path=MAIN_CONFIG_FIXTURE)
     workspace_layer = ConfigLayer(
         "workspace", file_path=WORKSPACE_CONFIG_FIXTURE, depends_on=["main"]
@@ -210,12 +210,12 @@ def preset_app_manager() -> LayeredConfigManager:
     manager.register(workspace_layer)
     manager.register(user_layer)
     yield manager
-    LayeredConfigManager.clear()
+    ConfigLayerManager.clear()
 
 
 @pytest.fixture()
-def preset_user_manager() -> LayeredConfigManager:
-    manager = LayeredConfigManager()
+def preset_user_manager() -> ConfigLayerManager:
+    manager = ConfigLayerManager()
     default_layer = ConfigLayer("default", file_path=USER_DEFAULT_FIXTURE)
     user1_layer = ConfigLayer("user1", file_path=USER1_FIXTURE, depends_on=["default"])
     user2_layer = ConfigLayer("user2", file_path=USER2_FIXTURE, depends_on=["default"])
@@ -224,7 +224,7 @@ def preset_user_manager() -> LayeredConfigManager:
     manager.register(user1_layer)
     manager.register(user2_layer)
     yield manager
-    LayeredConfigManager.clear()
+    ConfigLayerManager.clear()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,16 +100,32 @@ class _NestedCategoryValues(ConfigValues):
     flat_value: int = 10
 
 
+# One subdirectory per test module that may write output under
+# TEST_OUTPUT_DIR, so the layout is predictable even for modules that don't
+# currently exercise their own output dir fixture.
+_TEST_OUTPUT_SUBDIRS = (
+    "config",
+    "config_values",
+    "config_manager",
+    "config_layer",
+)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _clean_test_output_dir() -> None:
-    """Remove any leftover .test_output directory at the start of the session.
+    """Remove any leftover .test_output directory at the start of the session,
+    then recreate its per-module subdirectories.
 
     The various *_output_dir fixtures below only ever `mkdir(exist_ok=True)`
     and never clean up after themselves, so stale files from a previous run
     (e.g. written under an old field/category name) could otherwise bleed
-    into a fresh run's assertions.
+    into a fresh run's assertions. Subdirectories are (re)created eagerly
+    here so the expected layout exists even for modules that don't
+    currently request their output dir fixture.
     """
     shutil.rmtree(TEST_OUTPUT_DIR, ignore_errors=True)
+    for subdir in _TEST_OUTPUT_SUBDIRS:
+        (TEST_OUTPUT_DIR / subdir).mkdir(parents=True, exist_ok=True)
 
 
 @pytest.fixture(autouse=True)
@@ -131,46 +147,45 @@ def output_dir() -> pathlib.Path:
 
 
 @pytest.fixture(scope="session")
-def simple_config_output_dir() -> pathlib.Path:
-    """Output directory for tests.
+def config_output_dir() -> pathlib.Path:
+    """Output directory for tests in ``test_config.py``.
 
     Returns:
         pathlib.Path: path to test output directory.
 
     """
-    out_dir = TEST_OUTPUT_DIR / "simple_config"
+    out_dir = TEST_OUTPUT_DIR / "config"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 
 
 @pytest.fixture(scope="session")
-def layered_config_output_dir() -> pathlib.Path:
-    """Output directory for tests.
+def config_values_output_dir() -> pathlib.Path:
+    """Output directory for tests in ``test_config_values.py``.
 
     Returns:
         pathlib.Path: path to test output directory.
-
     """
-    out_dir = TEST_OUTPUT_DIR / "layered_config"
+    out_dir = TEST_OUTPUT_DIR / "config_values"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 
 
 @pytest.fixture(scope="session")
-def manager_output_dir() -> pathlib.Path:
-    """Output directory for tests.
+def config_manager_output_dir() -> pathlib.Path:
+    """Output directory for tests in ``test_config_manager.py``.
 
     Returns:
         pathlib.Path: path to test output directory.
     """
-    out_dir = TEST_OUTPUT_DIR / "manager"
+    out_dir = TEST_OUTPUT_DIR / "config_manager"
     out_dir.mkdir(exist_ok=True, parents=True)
     return out_dir
 
 
 @pytest.fixture(scope="session")
 def config_layer_output_dir() -> pathlib.Path:
-    """Output directory for tests.
+    """Output directory for tests in ``test_config_layer.py``.
 
     Returns:
         pathlib.Path: path to test output directory.

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -8,7 +8,7 @@ from json_config.api import (
     ConfigLayer,
     ConfigValues,
     LayeredConfig,
-    LayeredConfigManager,
+    ConfigLayerManager,
 )
 
 
@@ -30,7 +30,7 @@ def test_init_with_single_layer(
     class TestConfig(LayeredConfig[TestValues]):
         VALUES_CLASS = TestValues
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer("root", file_path=simple_config_file)
     manager.register(root_layer)
     manager.load_all()
@@ -41,7 +41,7 @@ def test_init_with_single_layer(
     assert config.values.int_value == 5
 
     config.values.int_value = 10
-    config.manager["root"].file_path = (
+    config.layer_manager["root"].file_path = (
         config_output_dir / f"{request.node.name}_config.json"
     )
     config.save()
@@ -66,7 +66,7 @@ def test_defaults_writing(
         VALUES_CLASS = TestValues
 
     # Setup manager
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
@@ -101,7 +101,7 @@ def test_defaults_writing(
 
 
 def test_layer_filter_limits_resolve_to_expected_values(
-    preset_app_manager: LayeredConfigManager,
+    preset_app_manager: ConfigLayerManager,
 ):
     """Test that layer filtering limits resolve to the expected values."""
 
@@ -131,7 +131,7 @@ def test_layer_filter_limits_resolve_to_expected_values(
 
 
 def test_invalid_layer_filter_resolve(
-    preset_app_manager: LayeredConfigManager,
+    preset_app_manager: ConfigLayerManager,
 ):
     """Test that resolving with an invalid layer filter raises a ValueError."""
 
@@ -190,7 +190,7 @@ def test_layered_config_save_produces_expected_nested_json(
     class TestConfig(LayeredConfig[category_values_class]):
         VALUES_CLASS = category_values_class
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
@@ -218,7 +218,7 @@ def test_layered_config_roundtrip_mutating_nested_category_value(
     class TestConfig(LayeredConfig[category_values_class]):
         VALUES_CLASS = category_values_class
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
@@ -258,7 +258,7 @@ def test_layered_config_deep_merges_nested_category_across_layers(
         file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register(root_layer)
     manager.register(child_layer)
     manager.load_all()
@@ -296,7 +296,7 @@ def test_layered_config_roundtrip_with_three_levels_of_nesting(
     class TestConfig(LayeredConfig[nested_category_values_class]):
         VALUES_CLASS = nested_category_values_class
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
@@ -358,7 +358,7 @@ def test_save_to_fresh_child_layer_persists_changed_values(
     class TestConfig(LayeredConfig[TestValues]):
         VALUES_CLASS = TestValues
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root", file_path=config_output_dir / f"{request.node.name}_root.json"
     )
@@ -403,7 +403,7 @@ def test_save_removes_override_that_now_matches_parent_layer(
     class TestConfig(LayeredConfig[TestValues]):
         VALUES_CLASS = TestValues
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root",
         file_path=config_output_dir / f"{request.node.name}_root.json",
@@ -465,7 +465,7 @@ def test_save_removes_nested_category_override_that_now_matches_parent(
         file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register(root_layer)
     manager.register(child_layer)
     manager.load_all()
@@ -527,7 +527,7 @@ def test_save_prunes_nested_category_field_that_now_matches_parent(
         file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register(root_layer)
     manager.register(child_layer)
     manager.load_all()
@@ -590,7 +590,7 @@ def test_save_prunes_three_level_nested_category_field_that_now_matches_parent(
         file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register(root_layer)
     manager.register(child_layer)
     manager.load_all()
@@ -655,7 +655,7 @@ def test_revert_value_removes_flat_override_from_current_layer(
     class TestConfig(LayeredConfig[TestValues]):
         VALUES_CLASS = TestValues
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root",
         file_path=config_output_dir / f"{request.node.name}_root.json",
@@ -708,7 +708,7 @@ def test_revert_value_falls_back_to_default_with_no_dependency_value(
     class TestConfig(LayeredConfig[TestValues]):
         VALUES_CLASS = TestValues
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root",
         file_path=config_output_dir / f"{request.node.name}_root.json",
@@ -746,7 +746,7 @@ def test_revert_value_removes_nested_category_override_from_current_layer(
         file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register(root_layer)
     manager.register(child_layer)
     manager.load_all()
@@ -802,7 +802,7 @@ def test_revert_value_with_dotted_path_only_reverts_leaf_field(
         file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register(root_layer)
     manager.register(child_layer)
     manager.load_all()
@@ -854,7 +854,7 @@ def test_revert_value_with_dotted_path_supports_three_levels_of_nesting(
         file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register(root_layer)
     manager.register(child_layer)
     manager.load_all()
@@ -904,7 +904,7 @@ def test_revert_value_raises_for_field_not_on_values_class(
     class TestConfig(LayeredConfig[TestValues]):
         VALUES_CLASS = TestValues
 
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer = ConfigLayer(
         "root",
         file_path=config_output_dir / f"{request.node.name}_root.json",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -20,7 +20,7 @@ def test_repr() -> None:
 
 def test_init_with_single_layer(
     simple_config_file: pathlib.Path,
-    layered_config_output_dir: pathlib.Path,
+    config_output_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
     @dataclasses.dataclass
@@ -42,13 +42,13 @@ def test_init_with_single_layer(
 
     config.values.int_value = 10
     config.manager["root"].file_path = (
-        layered_config_output_dir / f"{request.node.name}_config.json"
+        config_output_dir / f"{request.node.name}_config.json"
     )
     config.save()
 
 
 def test_defaults_writing(
-    layered_config_output_dir: pathlib.Path,
+    config_output_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
     """Test that defaults are written to the root layer file when saving."""
@@ -68,16 +68,16 @@ def test_defaults_writing(
     # Setup manager
     manager = LayeredConfigManager()
     root_layer = ConfigLayer(
-        "root", file_path=layered_config_output_dir / f"{request.node.name}_config.json"
+        "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
     extra_root_layer = ConfigLayer(
         "extra_root",
-        file_path=layered_config_output_dir
+        file_path=config_output_dir
         / f"{request.node.name}_extra_root_config.json",
     )
     extra_child_layer = ConfigLayer(
         "extra",
-        file_path=layered_config_output_dir / f"{request.node.name}_extra_config.json",
+        file_path=config_output_dir / f"{request.node.name}_extra_config.json",
         depends_on=["root"],
     )
     manager.register(root_layer)
@@ -181,7 +181,7 @@ def test_reset_values():
 
 def test_layered_config_save_produces_expected_nested_json(
     category_values_class: type[ConfigValues],
-    layered_config_output_dir: pathlib.Path,
+    config_output_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
     """Test that saving a ConfigValues with category fields produces the
@@ -192,7 +192,7 @@ def test_layered_config_save_produces_expected_nested_json(
 
     manager = LayeredConfigManager()
     root_layer = ConfigLayer(
-        "root", file_path=layered_config_output_dir / f"{request.node.name}_config.json"
+        "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
     manager.register(root_layer)
     manager.load_all()
@@ -210,7 +210,7 @@ def test_layered_config_save_produces_expected_nested_json(
 
 def test_layered_config_roundtrip_mutating_nested_category_value(
     category_values_class: type[ConfigValues],
-    layered_config_output_dir: pathlib.Path,
+    config_output_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
     """Test load -> resolve -> mutate a nested category value -> save round-trips."""
@@ -220,7 +220,7 @@ def test_layered_config_roundtrip_mutating_nested_category_value(
 
     manager = LayeredConfigManager()
     root_layer = ConfigLayer(
-        "root", file_path=layered_config_output_dir / f"{request.node.name}_config.json"
+        "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
     manager.register(root_layer)
     manager.load_all()
@@ -244,18 +244,18 @@ def test_layered_config_roundtrip_mutating_nested_category_value(
 
 def test_layered_config_deep_merges_nested_category_across_layers(
     category_values_class: type[ConfigValues],
-    layered_config_output_dir: pathlib.Path,
+    config_output_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
     """Test that a child layer overriding only part of a category is deep-merged
     with the root layer's defaults for that same category."""
     root_layer = ConfigLayer(
         "root",
-        file_path=layered_config_output_dir / f"{request.node.name}_root.json",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
     )
     child_layer = ConfigLayer(
         "child",
-        file_path=layered_config_output_dir / f"{request.node.name}_child.json",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
     manager = LayeredConfigManager()
@@ -287,7 +287,7 @@ def test_layered_config_deep_merges_nested_category_across_layers(
 
 def test_layered_config_roundtrip_with_three_levels_of_nesting(
     nested_category_values_class: type[ConfigValues],
-    layered_config_output_dir: pathlib.Path,
+    config_output_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
     """Regression test: save/load/mutate/save round-trips correctly through
@@ -298,7 +298,7 @@ def test_layered_config_roundtrip_with_three_levels_of_nesting(
 
     manager = LayeredConfigManager()
     root_layer = ConfigLayer(
-        "root", file_path=layered_config_output_dir / f"{request.node.name}_config.json"
+        "root", file_path=config_output_dir / f"{request.node.name}_config.json"
     )
     manager.register(root_layer)
     manager.load_all()
@@ -338,7 +338,7 @@ def test_layered_config_roundtrip_with_three_levels_of_nesting(
 
 
 def test_save_to_fresh_child_layer_persists_changed_values(
-    layered_config_output_dir: pathlib.Path,
+    config_output_dir: pathlib.Path,
     request: pytest.FixtureRequest,
 ):
     """Regression test: saving with a layer filter pointing at a child layer
@@ -360,11 +360,11 @@ def test_save_to_fresh_child_layer_persists_changed_values(
 
     manager = LayeredConfigManager()
     root_layer = ConfigLayer(
-        "root", file_path=layered_config_output_dir / f"{request.node.name}_root.json"
+        "root", file_path=config_output_dir / f"{request.node.name}_root.json"
     )
     child_layer = ConfigLayer(
         "child",
-        file_path=layered_config_output_dir / f"{request.node.name}_child.json",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
         depends_on=["root"],
     )
     manager.register(root_layer)
@@ -385,3 +385,534 @@ def test_save_to_fresh_child_layer_persists_changed_values(
 
     on_disk = json.loads(child_layer.file_path.read_text())
     assert on_disk == {"theme": "dark"}
+
+
+def test_save_removes_override_that_now_matches_parent_layer(
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Regression test: if a value in a child layer is set back to the same
+    value as its parent layer, the override must be removed from the child
+    layer entirely (rather than remaining as a stale, redundant override).
+    """
+
+    @dataclasses.dataclass
+    class TestValues(ConfigValues):
+        option1: int = 0
+
+    class TestConfig(LayeredConfig[TestValues]):
+        VALUES_CLASS = TestValues
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    # Seed root with option1=1, and child with an override of option1=2.
+    root_layer.set(option1=1)
+    root_layer.save()
+    child_layer.set(option1=2)
+    child_layer.save()
+
+    manager.load_all()
+    config = TestConfig(manager, layer_filter="child")
+    config.resolve()
+    assert config.values.option1 == 2
+
+    # Set the child's value back to the same value as the parent layer.
+    config.values.option1 = 1
+    config.save()
+
+    # The override must be gone entirely from the child layer...
+    assert "option1" not in child_layer.get_data()
+    on_disk = json.loads(child_layer.file_path.read_text())
+    assert on_disk == {}
+
+    # ...and the resolved value should still be correct (inherited from root).
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+    assert config2.values.option1 == 1
+
+
+def test_save_removes_nested_category_override_that_now_matches_parent(
+    category_values_class: type[ConfigValues],
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Regression test: the same override-pruning behavior must apply to
+    nested category values, not just flat top-level fields.
+
+    If a nested category value in a child layer is set back so the whole
+    category matches what the parent layer would already provide, the
+    entire category key must be removed from the child layer.
+    """
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager = LayeredConfigManager()
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    class TestConfig(LayeredConfig[category_values_class]):
+        VALUES_CLASS = category_values_class
+
+    # Seed root defaults: category_a.field_one=100, field_two=100.
+    config = TestConfig(manager)
+    config.save()
+
+    # Override category_a in the child layer.
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+    config2.values.category_a.field_one = 4000
+    config2.save()
+
+    assert child_layer.get_data() == {"category_a": {"field_one": 4000}}
+
+    # Now set the whole category back to match the parent's values exactly.
+    manager.load_all()
+    config3 = TestConfig(manager, layer_filter="child")
+    config3.resolve()
+    assert config3.values.category_a.field_one == 4000
+    config3.values.category_a.field_one = 100
+    config3.save()
+
+    # The entire category override must be gone from the child layer...
+    assert "category_a" not in child_layer.get_data()
+    on_disk = json.loads(child_layer.file_path.read_text())
+    assert "category_a" not in on_disk
+
+    # ...and the resolved value should still be correct (inherited from root).
+    manager.load_all()
+    config4 = TestConfig(manager, layer_filter="child")
+    config4.resolve()
+    assert config4.values.category_a.field_one == 100
+    assert config4.values.category_a.field_two == 100
+
+
+def test_save_prunes_nested_category_field_that_now_matches_parent(
+    category_values_class: type[ConfigValues],
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Pruning is per-field within nested categories: if only part of an
+    overridden category is reverted to the parent's value while another
+    field in that same category still diverges, only the reverted field is
+    dropped -- the still-diverging field remains as an override, and the
+    matching one does not.
+    """
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager = LayeredConfigManager()
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    class TestConfig(LayeredConfig[category_values_class]):
+        VALUES_CLASS = category_values_class
+
+    # Seed root defaults: category_a.field_one=100, field_two=100.
+    config = TestConfig(manager)
+    config.save()
+
+    # Override both fields of category_a in the child layer.
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+    config2.values.category_a.field_one = 4000
+    config2.values.category_a.field_two = 5000
+    config2.save()
+
+    assert child_layer.get_data() == {
+        "category_a": {"field_one": 4000, "field_two": 5000}
+    }
+
+    # Revert only field_one back to the parent's value; field_two still diverges.
+    manager.load_all()
+    config3 = TestConfig(manager, layer_filter="child")
+    config3.resolve()
+    config3.values.category_a.field_one = 100
+    config3.save()
+
+    # Only field_two remains as an override; field_one was pruned since it
+    # now matches the parent's value.
+    assert child_layer.get_data() == {"category_a": {"field_two": 5000}}
+    on_disk = json.loads(child_layer.file_path.read_text())
+    assert on_disk == {"category_a": {"field_two": 5000}}
+
+    manager.load_all()
+    config4 = TestConfig(manager, layer_filter="child")
+    config4.resolve()
+    assert config4.values.category_a.field_one == 100
+    assert config4.values.category_a.field_two == 5000
+
+
+def test_save_prunes_three_level_nested_category_field_that_now_matches_parent(
+    nested_category_values_class: type[ConfigValues],
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Per-field pruning must also work through three levels of category
+    nesting (category_a.sub_category.x/y): reverting just ``x`` back to the
+    parent's value should drop only ``x``, leaving ``y`` (still diverging)
+    and the rest of the structure intact.
+    """
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager = LayeredConfigManager()
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    class TestConfig(LayeredConfig[nested_category_values_class]):
+        VALUES_CLASS = nested_category_values_class
+
+    # Seed root defaults: category_a.{field_one,field_two}=100,
+    # category_a.sub_category.{x,y}=0.
+    config = TestConfig(manager)
+    config.save()
+
+    # Override both x and y (three levels deep) in the child layer.
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+    config2.values.category_a.sub_category.x = 42
+    config2.values.category_a.sub_category.y = 84
+    config2.save()
+
+    assert child_layer.get_data() == {
+        "category_a": {"sub_category": {"x": 42, "y": 84}}
+    }
+
+    # Revert only x back to the parent's value; y still diverges.
+    manager.load_all()
+    config3 = TestConfig(manager, layer_filter="child")
+    config3.resolve()
+    config3.values.category_a.sub_category.x = 0
+    config3.save()
+
+    # Only y remains as an override, nested three levels deep; x and the
+    # rest of category_a were pruned entirely since they now match root.
+    assert child_layer.get_data() == {
+        "category_a": {"sub_category": {"y": 84}}
+    }
+    on_disk = json.loads(child_layer.file_path.read_text())
+    assert on_disk == {"category_a": {"sub_category": {"y": 84}}}
+
+    manager.load_all()
+    config4 = TestConfig(manager, layer_filter="child")
+    config4.resolve()
+    assert config4.values.category_a.field_one == 100
+    assert config4.values.category_a.field_two == 100
+    assert config4.values.category_a.sub_category.x == 0
+    assert config4.values.category_a.sub_category.y == 84
+
+
+def test_revert_value_removes_flat_override_from_current_layer(
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """``revert_value`` should immediately drop a flat field's override
+    from the current layer's own data and update ``values`` in-memory to
+    whatever would be inherited from that layer's dependencies.
+    """
+
+    @dataclasses.dataclass
+    class TestValues(ConfigValues):
+        option1: int = 0
+
+    class TestConfig(LayeredConfig[TestValues]):
+        VALUES_CLASS = TestValues
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    root_layer.set(option1=1)
+    root_layer.save()
+    child_layer.set(option1=2)
+    child_layer.save()
+
+    manager.load_all()
+    config = TestConfig(manager, layer_filter="child")
+    config.resolve()
+    assert config.values.option1 == 2
+
+    field = dataclasses.fields(TestValues)[0]
+    assert field.name == "option1"
+    config.revert_value(field)
+
+    # The override is gone from the layer's own data immediately...
+    assert "option1" not in child_layer.get_data()
+    # ...and the in-memory value now reflects the inherited (root) value.
+    assert config.values.option1 == 1
+
+    # Persisting confirms the override stays gone on disk too.
+    config.save()
+    on_disk = json.loads(child_layer.file_path.read_text())
+    assert on_disk == {}
+
+
+def test_revert_value_falls_back_to_default_with_no_dependency_value(
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """If no dependency layer provides a value for the reverted field
+    either, ``revert_value`` should fall back to the field's own default."""
+
+    @dataclasses.dataclass
+    class TestValues(ConfigValues):
+        option1: int = 7
+
+    class TestConfig(LayeredConfig[TestValues]):
+        VALUES_CLASS = TestValues
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    manager.register(root_layer)
+    manager.load_all()
+
+    config = TestConfig(manager)
+    config.values.option1 = 99
+    config.save()
+    assert root_layer.get_data() == {"option1": 99}
+
+    field = dataclasses.fields(TestValues)[0]
+    config.revert_value(field)
+
+    assert "option1" not in root_layer.get_data()
+    assert config.values.option1 == 7
+
+
+def test_revert_value_removes_nested_category_override_from_current_layer(
+    category_values_class: type[ConfigValues],
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """``revert_value`` should also work for a category field, removing the
+    whole category's override from the current layer and restoring the
+    in-memory value to whatever is inherited from its dependencies.
+    """
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager = LayeredConfigManager()
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    class TestConfig(LayeredConfig[category_values_class]):
+        VALUES_CLASS = category_values_class
+
+    # Seed root defaults: category_a.field_one=100, field_two=100.
+    config = TestConfig(manager)
+    config.save()
+
+    # Override category_a in the child layer.
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+    config2.values.category_a.field_one = 4000
+    config2.values.category_a.field_two = 5000
+    config2.save()
+
+    assert child_layer.get_data() == {
+        "category_a": {"field_one": 4000, "field_two": 5000}
+    }
+
+    category_a_field = next(
+        f for f in dataclasses.fields(category_values_class) if f.name == "category_a"
+    )
+    config2.revert_value(category_a_field)
+
+    # The whole category override is gone from the layer immediately...
+    assert "category_a" not in child_layer.get_data()
+    # ...and the in-memory value now reflects the inherited (root) values.
+    assert config2.values.category_a.field_one == 100
+    assert config2.values.category_a.field_two == 100
+
+
+def test_revert_value_with_dotted_path_only_reverts_leaf_field(
+    category_values_class: type[ConfigValues],
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """A dot-separated path string lets ``revert_value`` target a single
+    leaf field nested within a category, leaving sibling overrides in that
+    same category untouched -- e.g.::
+
+        config.revert_value("category_a.field_one")
+    """
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager = LayeredConfigManager()
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    class TestConfig(LayeredConfig[category_values_class]):
+        VALUES_CLASS = category_values_class
+
+    # Seed root defaults: category_a.field_one=100, field_two=100.
+    config = TestConfig(manager)
+    config.save()
+
+    # Override both fields of category_a in the child layer.
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+    config2.values.category_a.field_one = 4000
+    config2.values.category_a.field_two = 5000
+    config2.save()
+
+    assert child_layer.get_data() == {
+        "category_a": {"field_one": 4000, "field_two": 5000}
+    }
+
+    # Revert only field_one via its dotted path; field_two must stay overridden.
+    config2.revert_value("category_a.field_one")
+
+    assert child_layer.get_data() == {"category_a": {"field_two": 5000}}
+    assert config2.values.category_a.field_one == 100
+    assert config2.values.category_a.field_two == 5000
+
+    config2.save()
+    on_disk = json.loads(child_layer.file_path.read_text())
+    assert on_disk == {"category_a": {"field_two": 5000}}
+
+
+def test_revert_value_with_dotted_path_supports_three_levels_of_nesting(
+    nested_category_values_class: type[ConfigValues],
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """A dotted path can also address a leaf field three levels deep, e.g.
+    ``"category_a.sub_category.x"``."""
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    child_layer = ConfigLayer(
+        "child",
+        file_path=config_output_dir / f"{request.node.name}_child.json",
+        depends_on=["root"],
+    )
+    manager = LayeredConfigManager()
+    manager.register(root_layer)
+    manager.register(child_layer)
+    manager.load_all()
+
+    class TestConfig(LayeredConfig[nested_category_values_class]):
+        VALUES_CLASS = nested_category_values_class
+
+    # Seed root defaults: category_a.sub_category.{x,y}=0.
+    config = TestConfig(manager)
+    config.save()
+
+    # Override both x and y (three levels deep) in the child layer.
+    manager.load_all()
+    config2 = TestConfig(manager, layer_filter="child")
+    config2.resolve()
+    config2.values.category_a.sub_category.x = 42
+    config2.values.category_a.sub_category.y = 84
+    config2.save()
+
+    assert child_layer.get_data() == {
+        "category_a": {"sub_category": {"x": 42, "y": 84}}
+    }
+
+    # Revert only x via its dotted path; y must stay overridden.
+    config2.revert_value("category_a.sub_category.x")
+
+    assert child_layer.get_data() == {"category_a": {"sub_category": {"y": 84}}}
+    assert config2.values.category_a.sub_category.x == 0
+    assert config2.values.category_a.sub_category.y == 84
+
+
+def test_revert_value_raises_for_field_not_on_values_class(
+    config_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """``revert_value`` should reject a field that doesn't belong to this
+    config's ``VALUES_CLASS``."""
+
+    @dataclasses.dataclass
+    class TestValues(ConfigValues):
+        option1: int = 0
+
+    @dataclasses.dataclass
+    class OtherValues(ConfigValues):
+        other_option: int = 0
+
+    class TestConfig(LayeredConfig[TestValues]):
+        VALUES_CLASS = TestValues
+
+    manager = LayeredConfigManager()
+    root_layer = ConfigLayer(
+        "root",
+        file_path=config_output_dir / f"{request.node.name}_root.json",
+    )
+    manager.register(root_layer)
+    manager.load_all()
+
+    config = TestConfig(manager)
+    other_field = dataclasses.fields(OtherValues)[0]
+    with pytest.raises(ValueError):
+        config.revert_value(other_field)

--- a/tests/core/test_config_manager.py
+++ b/tests/core/test_config_manager.py
@@ -157,7 +157,7 @@ def test_resolve_many(
     }
 
 
-def test_root_layers(output_dir: pathlib.Path):
+def test_root_layers(config_manager_output_dir: pathlib.Path):
     manager = LayeredConfigManager()
     for i in range(1, 4):
         root_layer = ConfigLayer(f"root{i}")

--- a/tests/core/test_config_values.py
+++ b/tests/core/test_config_values.py
@@ -1,4 +1,6 @@
 import dataclasses
+import json
+import pathlib
 
 import pytest
 
@@ -165,3 +167,32 @@ def test_replace_updates_deeply_nested_category_and_preserves_siblings(
     # Unrelated top-level category and flat field are untouched.
     assert updated.category_b.label == "test"
     assert updated.flat_value == 10
+
+
+# ---------------------------------------------------------------------------
+# JSON round-tripping (to_dict()/replace() against actual files on disk)
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_json_round_trip_supports_three_levels_of_nesting(
+    nested_category_values_class: type[ConfigValues],
+    config_values_output_dir: pathlib.Path,
+    request: pytest.FixtureRequest,
+):
+    """Test that to_dict() produces a JSON-serializable structure that can be
+    written to disk and loaded back via replace() without any loss, through
+    three levels of category nesting."""
+    values = nested_category_values_class()
+    values.category_a.field_one = 1920
+    values.category_a.sub_category.x = 42
+    values.category_a.sub_category.y = 84
+    values.category_b.label = "prod"
+    values.flat_value = 99
+
+    output_file = config_values_output_dir / f"{request.node.name}.json"
+    output_file.write_text(json.dumps(values.to_dict(), indent=4))
+
+    loaded = json.loads(output_file.read_text())
+    restored = nested_category_values_class().replace(loaded)
+
+    assert restored.to_dict() == values.to_dict()

--- a/tests/core/test_layer_manager.py
+++ b/tests/core/test_layer_manager.py
@@ -2,20 +2,20 @@ import pathlib
 
 import pytest
 
-from json_config.api import ConfigLayer, LayeredConfigManager
+from json_config.api import ConfigLayer, ConfigLayerManager
 
 
-def test_repr(preset_app_manager: LayeredConfigManager) -> None:
+def test_repr(preset_app_manager: ConfigLayerManager) -> None:
     """Test the __repr__ method."""
     assert (
         repr(preset_app_manager)
-        == f"LayeredConfigManager(layers={preset_app_manager.sorted_names()})"
+        == f"ConfigLayerManager(layers={preset_app_manager.sorted_names()})"
     )
 
 
 def test_init_with_single_layer(simple_config_file: pathlib.Path) -> None:
     """Test initializing with a single layer and resolving values."""
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     layer = ConfigLayer("main", file_path=simple_config_file)
     manager.register(layer)
     manager.load_all()
@@ -24,7 +24,7 @@ def test_init_with_single_layer(simple_config_file: pathlib.Path) -> None:
 
 def test_resiter_layer_with_same_name_raises_error() -> None:
     """Test registering a layer with the same name raises a ValueError."""
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     layer1 = ConfigLayer("main")
     layer2 = ConfigLayer("main")
     manager.register(layer1)
@@ -34,7 +34,7 @@ def test_resiter_layer_with_same_name_raises_error() -> None:
 
 def test_unregister_layer() -> None:
     """Test unregistering a layer."""
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     layer = ConfigLayer("test")
     manager.register(layer)
     assert "test" in manager._layers
@@ -48,7 +48,7 @@ def test_init_with_multiple_layers(
     user_config_file: pathlib.Path,
 ) -> None:
     """Test resolving values from multiple layers with dependencies."""
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     main_layer = ConfigLayer("main", file_path=main_config_file)
     workspace_layer = ConfigLayer(
         "workspace", file_path=workspace_config_file, depends_on=["main"]
@@ -75,7 +75,7 @@ def test_init_from_path_tree(
 ) -> None:
     """Test resolving values from multiple layers with dependencies."""
     path_tree = {main_config_file: {workspace_config_file: {user_config_file: {}}}}
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     manager.register_from_paths_tree(path_tree)
     manager.load_all()
 
@@ -87,14 +87,14 @@ def test_init_from_path_tree(
 
 def test_load_layer_missing_dependancy_value_error():
     """Test that loading a layer with a missing dependancy raises a ValueError."""
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     test_layer = ConfigLayer("test", depends_on=["missing"])
     manager.register(test_layer)
     with pytest.raises(ValueError):
         manager.load_all()
 
 
-def test_loading_to_layer(preset_app_manager: LayeredConfigManager) -> None:
+def test_loading_to_layer(preset_app_manager: ConfigLayerManager) -> None:
     """Test loading a layer from its file and resolving it."""
     preset_app_manager.load_all()
     config_dict = preset_app_manager.resolve(up_to="main")
@@ -107,7 +107,7 @@ def test_loading_to_layer(preset_app_manager: LayeredConfigManager) -> None:
     )
 
 
-def test_load_branching_configs(preset_user_manager: LayeredConfigManager) -> None:
+def test_load_branching_configs(preset_user_manager: ConfigLayerManager) -> None:
     """Test loading a branching config with multiple layers."""
     ...
     preset_user_manager.load_all()
@@ -126,7 +126,7 @@ def test_multiple_root_configs(
     workspace_config_file: pathlib.Path,
 ) -> None:
     """Test resolving a config with multiple root layers."""
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer_1 = ConfigLayer("root_1", file_path=main_config_file)
     root_layer_2 = ConfigLayer("root_2", file_path=workspace_config_file)
     manager.register(root_layer_1)
@@ -144,7 +144,7 @@ def test_resolve_many(
     workspace_config_file: pathlib.Path,
 ) -> None:
     """Test resolving multiple independent branches and merging them in order."""
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     root_layer_1 = ConfigLayer("root_1", file_path=main_config_file)
     root_layer_2 = ConfigLayer("root_2", file_path=workspace_config_file)
     manager.register(root_layer_1)
@@ -157,8 +157,8 @@ def test_resolve_many(
     }
 
 
-def test_root_layers(config_manager_output_dir: pathlib.Path):
-    manager = LayeredConfigManager()
+def test_root_layers(layer_manager_output_dir: pathlib.Path):
+    manager = ConfigLayerManager()
     for i in range(1, 4):
         root_layer = ConfigLayer(f"root{i}")
         manager.register(root_layer)
@@ -175,7 +175,7 @@ def test_resolve_up_to_missing_dependency_raises_value_error() -> None:
     dependency must raise a ValueError, consistent with the no-`up_to` path
     (sorted_names()/load_all()), instead of a bare KeyError.
     """
-    manager = LayeredConfigManager()
+    manager = ConfigLayerManager()
     test_layer = ConfigLayer("test", depends_on=["missing"])
     manager.register(test_layer)
 


### PR DESCRIPTION
Implemented true per-field (recursive) pruning of config layer overrides:

1. **`Layer Helpers`**
   - Added `deep_diff_dicts(current, baseline)`: recursively computes only the parts of `current` that diverge from `baseline`, descending into nested dicts (categories) so partial matches within a category are pruned individually instead of treating the whole category as one blob.
   - Added `get_nested`, `pop_nested`, and `nest_value` — generic helpers for reading/removing/wrapping values at a nested dict path.

2. **`ConfigLayer`**
   - Added `ConfigLayer.replace_data(data)`: fully replaces the layer's raw data (rather than merging), used to write the pruned diff back cleanly.
   - Kept `unset()` as a small public utility (no longer used internally, but harmless to leave available).
   - Added `ConfigLayer.unset_path(path)`, which removes a nested override (pruning now-empty parent containers) without disturbing sibling overrides.

3. **`LayeredConfig`**
   - `write_to_layer()` now computes `layer_helpers.deep_diff_dicts(current_dict, baseline)` and calls `layer.replace_data(diff)`, so the layer ends up containing exactly (and only) the overrides that still diverge from its dependencies, at any nesting depth.
   - Added `revert_value` method that accepts `dataclasses.Field | str` and unsets value either from given `Field` or dotted string path: `categoryA.categoryB.optionName`

4. **Tests** (`config`)
   - Updated `test_save_removes_nested_category_override_that_now_matches_parent` to expect that unrelated fields within a category aren't carried along as overrides.
   - Replaced the old "keeps whole category" test with `test_save_prunes_nested_category_field_that_now_matches_parent`, verifying that reverting one field in a category prunes just that field while a still-diverging sibling field remains.
   - Added `test_save_prunes_three_level_nested_category_field_that_now_matches_parent` to confirm pruning works correctly through three levels of nesting (`category_a.sub_category.x/y`).